### PR TITLE
Chat-SpaceのDB設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,44 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+# ChatSpace DB設計
+## messagesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|body|text||
+|image|string||
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :user
+- belongs_to :group
+
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false, add_index: true|
+|email|string|null: false, unique: true|
+|password|string|null: false|
+### Association
+- has_many :groups_users
+- has_many :groups, through: groups_users
+- has_many :messages
+
+## groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false, unique: true|
+### Association
+- has_many :groups_users
+- has_many :users, through: groups_users
+- has_many :messages
+
+## groups_usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :group
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Things you may want to cover:
 |------|----|-------|
 |body|text||
 |image|string||
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user|references|null: false, foreign_key: true|
+|group|references|null: false, foreign_key: true|
 ### Association
 - belongs_to :user
 - belongs_to :group
@@ -38,12 +38,12 @@ Things you may want to cover:
 ## usersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|name|string|null: false, add_index: true|
+|name|string|null: false, index: true|
 |email|string|null: false, unique: true|
 |password|string|null: false|
 ### Association
 - has_many :groups_users
-- has_many :groups, through: groups_users
+- has_many :groups, through: :groups_users
 - has_many :messages
 
 ## groupsテーブル
@@ -52,14 +52,14 @@ Things you may want to cover:
 |name|string|null: false, unique: true|
 ### Association
 - has_many :groups_users
-- has_many :users, through: groups_users
+- has_many :users, through: :groups_users
 - has_many :messages
 
 ## groups_usersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user|references|null: false, foreign_key: true|
+|group|references|null: false, foreign_key: true|
 ### Association
 - belongs_to :group
 - belongs_to :user


### PR DESCRIPTION
# what
chat-spaceのDB設計をREADME.mdに記述しました。
(1)messagesテーブル
(2)usersテーブル
(3)groupsテーブル
(4) groups_usersテーブル（中間テーブル）
以上4つのテーブルの作成および、各テーブル間のリレーションも記述しています。

# why
chat-spaceの根幹であるデータベースを作成